### PR TITLE
Fix CIDR normalization and GPG installation issues

### DIFF
--- a/usr/local/lib/site_perl/BadIPs.pm
+++ b/usr/local/lib/site_perl/BadIPs.pm
@@ -673,6 +673,7 @@ sub _load_config {
             if ($section =~ /^detector:(.+)/) {
                 my $detector_name = $1;
                 my $d = $c->{$section};
+                $log->debug("Processing detector section: $section with full dump: " . Dumper($d));
 
                 # Collect units from this detector
                 if ($d->{units}) {
@@ -779,10 +780,10 @@ sub _load_config {
     # Normalize comma lists
     $accum{journal_units}         = _csv_to_array($accum{journal_units});
     $accum{bad_conn_patterns}     = _csv_to_array($accum{bad_conn_patterns});
-    $accum{never_block_cidrs}     = _csv_to_array($accum{never_block_cidrs});
-    $accum{never_block_cidrs_v6}  = _csv_to_array($accum{never_block_cidrs_v6});
-    $accum{always_block_cidrs}    = _csv_to_array($accum{always_block_cidrs});
-    $accum{always_block_cidrs_v6} = _csv_to_array($accum{always_block_cidrs_v6});
+    $accum{never_block_cidrs}     = _normalize_cidrs(_csv_to_array($accum{never_block_cidrs}));
+    $accum{never_block_cidrs_v6}  = _normalize_cidrs(_csv_to_array($accum{never_block_cidrs_v6}));
+    $accum{always_block_cidrs}    = _normalize_cidrs(_csv_to_array($accum{always_block_cidrs}));
+    $accum{always_block_cidrs_v6} = _normalize_cidrs(_csv_to_array($accum{always_block_cidrs_v6}));
     $accum{file_sources}          = _csv_to_array($accum{file_sources});
     $accum{public_blocklist_urls} = _csv_to_array($accum{public_blocklist_urls});
 
@@ -812,6 +813,47 @@ sub _csv_to_array {
         $t;
     } split(/\s*,\s*/, $s);
     return \@x;
+}
+
+=head2 _normalize_cidrs
+
+Description:
+    Normalize CIDR entries by ensuring all IP addresses have netmask notation.
+    Bare IPv4 addresses get /32, bare IPv6 addresses get /128.
+    This prevents errors in Net::CIDR::cidrlookup which expects proper CIDR format.
+
+Arguments:
+    $cidrs – arrayref of CIDR strings (may contain bare IPs).
+
+Returns:
+    Arrayref of normalized CIDR strings.
+
+=cut
+
+sub _normalize_cidrs {
+    my ($cidrs) = @_;
+    return [] unless defined $cidrs && ref($cidrs) eq 'ARRAY';
+
+    my @normalized = map {
+        my $entry = $_;
+        # Skip empty entries
+        next unless defined $entry && length($entry);
+
+        # If it already has a slash, it's already a CIDR
+        if ($entry =~ m{/}) {
+            $entry;
+        }
+        # Check if it's an IPv6 address (contains colons)
+        elsif ($entry =~ /:/) {
+            "$entry/128";
+        }
+        # Otherwise treat as IPv4
+        else {
+            "$entry/32";
+        }
+    } @$cidrs;
+
+    return \@normalized;
 }
 
 =head2 _auto_discover_sources

--- a/website/install.sh
+++ b/website/install.sh
@@ -172,10 +172,49 @@ detect_os() {
     fi
 }
 
+# Check if gpg is installed and install if needed
+check_gpg() {
+    if ! command -v gpg &> /dev/null; then
+        echo ""
+        echo -e "${YELLOW}GPG is not installed.${NC}"
+        echo ""
+        echo "GPG is required to verify the Bad IPs package signature."
+        echo ""
+        read -p "Would you like to install GPG now? [Y/n]: " INSTALL_GPG
+
+        if [[ "$INSTALL_GPG" =~ ^[Nn]$ ]]; then
+            echo ""
+            echo -e "${YELLOW}Installation cancelled.${NC}"
+            echo ""
+            echo "To install GPG manually and retry:"
+            echo "  sudo apt-get install gpg"
+            echo "  bash <(curl -fsSL https://projects.thedude.vip/bad-ips/install.sh)"
+            exit 0
+        fi
+
+        echo ""
+        echo -e "${BLUE}Installing GPG...${NC}"
+        if DEBIAN_FRONTEND=noninteractive apt-get install -y gpg; then
+            echo ""
+            echo -e "${GREEN}✓${NC} GPG installed successfully"
+        else
+            echo ""
+            echo -e "${RED}✗${NC} Failed to install GPG"
+            echo ""
+            echo "Please install GPG manually:"
+            echo "  sudo apt-get install gpg"
+            exit 1
+        fi
+    fi
+}
+
 # Add GPG key
 add_gpg_key() {
     echo ""
     echo -e "${BLUE}Adding Silver Linings, LLC GPG key...${NC}"
+
+    # Ensure GPG is installed
+    check_gpg
 
     # Remove old keys from both possible locations to avoid conflicts
     rm -f /etc/apt/keyrings/silver-linings.gpg


### PR DESCRIPTION
This commit addresses two critical issues:

1. CIDR Normalization (BadIPs.pm):
   - Added _normalize_cidrs() function to ensure all IP addresses in never_block_cidrs and always_block_cidrs have proper CIDR notation (e.g., bare IPs get /32 for IPv4, /128 for IPv6)
   - Fixes "Thread terminated abnormally: This doesn't look like start-end" error in Net::CIDR::cidrlookup when processing Spamhaus blocklists
   - Resolves issue where bare IPs in configuration caused thread crashes in PublicBlocklistPlugins

2. GPG Installation (install.sh):
   - Added check_gpg() function to detect if GPG is installed
   - Prompts user for permission before installing GPG package
   - Provides clear feedback and manual installation instructions
   - Fixes "gpg: command not found" error during installation on minimal Ubuntu/Debian systems

Both fixes improve robustness and user experience during installation and runtime operation.

Tested on: Ubuntu 24.04 (10.20.3.128)